### PR TITLE
Set maps to only appear for checkins

### DIFF
--- a/src/components/card.js
+++ b/src/components/card.js
@@ -56,6 +56,7 @@ class TogetherCard extends React.Component {
     super(props);
     this.renderPhotos = this.renderPhotos.bind(this);
     this.renderLocation = this.renderLocation.bind(this);
+    this.renderCheckin = this.renderCheckin.bind(this);
     this.renderContent = this.renderContent.bind(this);
     this.renderMedia = this.renderMedia.bind(this);
     this.handleLike = this.handleLike.bind(this);
@@ -141,7 +142,7 @@ class TogetherCard extends React.Component {
     return null;
   }
 
-  renderLocation(location) {
+  renderCheckin(location) {
     let lat = false;
     let lng = false;
     if (!location) {
@@ -168,6 +169,18 @@ class TogetherCard extends React.Component {
           <Marker position={[lat,lng]}></Marker>
         </Map>
       );
+    }
+
+    return null;
+  }
+
+  renderLocation(location) {
+    if (!location) {
+      return null;
+    }
+
+    if (location.name !== undefined) {
+      return (<CardContent>{location.name}</CardContent>);
     }
 
     return null;
@@ -250,6 +263,7 @@ class TogetherCard extends React.Component {
         {this.renderContent()}
 
         {this.renderLocation(item.location)}
+        {this.renderCheckin(item.checkin)}
 
         <CardActions>
           <Tooltip title="Like" placement="top">

--- a/src/reducers/post-kinds.js
+++ b/src/reducers/post-kinds.js
@@ -23,7 +23,7 @@ const postKinds = [
     name: 'Notes',
     icon: NoteIcon,
     selected: false,
-    filter: (post) => (post.content && !post.name && !Array.isArray(post.photo)),
+    filter: (post) => (post.content && !post.name && !Array.isArray(post.photo) && !post.checkin),
   },
   {
     id: 'photo',
@@ -58,7 +58,7 @@ const postKinds = [
     name: 'Checkins',
     icon: CheckinIcon,
     selected: false,
-    filter: (post) => (post.location),
+    filter: (post) => (post.checkin),
   },
   {
     id: 'event',

--- a/src/reducers/post-kinds.js
+++ b/src/reducers/post-kinds.js
@@ -23,7 +23,7 @@ const postKinds = [
     name: 'Notes',
     icon: NoteIcon,
     selected: false,
-    filter: (post) => (post.content && !post.name && !Array.isArray(post.photo) && !post.checkin),
+    filter: (post) => (post.content && !post.name && !Array.isArray(post.photo) && !post.checkin && !post.video && !post.audio && !post.type !== 'event'),
   },
   {
     id: 'photo',


### PR DESCRIPTION
Looking at it, it seems like having maps on every post that provides location information provides a lot of visual clutter. I recommend only showing a map on a checkin post, and showing the location name for posts with location information. Then if a user chooses a "map view" instead of a "card view", we could still use the location information to map the card