### PR TITLE
Clean timeline

### DIFF
--- a/src/reducers/post-kinds.js
+++ b/src/reducers/post-kinds.js
@@ -23,7 +23,7 @@ const postKinds = [
     name: 'Notes',
     icon: NoteIcon,
     selected: false,
-    filter: (post) => (post.content && !post.name && !Array.isArray(post.photo)),
+    filter: (post) => (post.content && !post.name && !Array.isArray(post.photo) && !post.checkin),
   },
   {
     id: 'photo',
@@ -58,7 +58,7 @@ const postKinds = [
     name: 'Checkins',
     icon: CheckinIcon,
     selected: false,
-    filter: (post) => (post.location),
+    filter: (post) => (post.checkin),
   },
   {
     id: 'event',

--- a/src/reducers/post-kinds.js
+++ b/src/reducers/post-kinds.js
@@ -23,7 +23,7 @@ const postKinds = [
     name: 'Notes',
     icon: NoteIcon,
     selected: false,
-    filter: (post) => (post.content && !post.name && !Array.isArray(post.photo) && !post.checkin),
+    filter: (post) => (post.content && !post.name && !Array.isArray(post.photo) && !post.checkin && !post.video && !post.audio && !post.type !== 'event'),
   },
   {
     id: 'photo',


### PR DESCRIPTION
cleaned up the notes stream by excluding other post types (since that is what the "all" filter view is for). Also, location and checkin are two different property types, so the checkin tab should really be for intentional checkins as opposed to just notes with location data.